### PR TITLE
f6 - Feat: flexible containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@ WORKDIR /app
 
 COPY --from=build /workspace/target/*.jar app.jar
 
+
+# metadata: the container listens on 8080 by default
 EXPOSE 8080
 
-ENV MODEL_HOST=http://host.docker.internal:8081
+# default environment values (can be overridden by docker run / compose)
+ENV APP_PORT=8080
+ENV MODEL_SERVICE_URL=http://model-service:8081
 
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/src/main/java/frontend/ctrl/FrontendController.java
+++ b/src/main/java/frontend/ctrl/FrontendController.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,20 +24,20 @@ public class FrontendController {
 
     private RestTemplateBuilder rest;
 
-    public FrontendController(RestTemplateBuilder rest, Environment env) {
+    public FrontendController(RestTemplateBuilder rest, @Value("${model.service.url}") String modelServiceUrl) {
         this.rest = rest;
-        this.modelHost = env.getProperty("MODEL_HOST");
+        this.modelHost = modelServiceUrl;
         assertModelHost();
     }
 
     private void assertModelHost() {
         if (modelHost == null || modelHost.strip().isEmpty()) {
-            System.err.println("ERROR: ENV variable MODEL_HOST is null or empty");
+            System.err.println("ERROR: property model.service.url (or env MODEL_SERVICE_URL) is null or empty");
             System.exit(1);
         }
         modelHost = modelHost.strip();
         if (modelHost.indexOf("://") == -1) {
-            var m = "ERROR: ENV variable MODEL_HOST is missing protocol, like \"http://...\" (was: \"%s\")\n";
+            var m = "ERROR: property model.service.url (or env MODEL_SERVICE_URL) is missing protocol, like \"http://...\" (was: \"%s\")\n";
             System.err.printf(m, modelHost);
             System.exit(1);
         } else {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
+server.port=${APP_PORT:8080}
+
+# URL used by the frontend to call the model-service. Read from env MODEL_SERVICE_URL
+model.service.url=${MODEL_SERVICE_URL:http://model-service:8081}
 


### PR DESCRIPTION
This PR implements the F6 requirement for flexible container configuration.

- APP_PORT now controls the Spring Boot port, defaulting to 8080  
- MODEL_SERVICE_URL controls the URL used to reach the model-service  
- application.properties updated to use Spring placeholders  
- Controller uses @Value injection
- Dockerfile provides defaults (APP_PORT=8080, MODEL_SERVICE_URL=http://model-service:8081)  

These changes allow the app container to adapt to different deployment environments without code changes.

### How to verify

1. Build locally:
   docker build -t sms-app:dev .

2. Run with defaults:
   docker run --rm -p 8080:8080 sms-app:dev
   → Expected: Tomcat starts on port 8080
   → Expected: MODEL_SERVICE_URL prints as http://model-service:8081

3. Run with overridden values:
   docker run --rm \
     -e APP_PORT=9090 \
     -e MODEL_SERVICE_URL=http://example:9999 \
     -p 9090:9090 \
     sms-app:dev

   → Expected: Tomcat starts on port 9090  
   → Expected: MODEL_SERVICE_URL prints http://example:9999