### PR TITLE
Fix: swagger ui

### DIFF
--- a/src/main/java/frontend/ctrl/ApiDocsProxyController.java
+++ b/src/main/java/frontend/ctrl/ApiDocsProxyController.java
@@ -1,0 +1,59 @@
+package frontend.ctrl;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Controller
+public class ApiDocsProxyController {
+
+    private final RestTemplateBuilder restTemplateBuilder;
+    private final String modelServiceUrl;
+
+    public ApiDocsProxyController(RestTemplateBuilder restTemplateBuilder,
+            @Value("${model.service.url}") String modelServiceUrl) {
+        this.restTemplateBuilder = restTemplateBuilder;
+        this.modelServiceUrl = modelServiceUrl;
+    }
+
+    @GetMapping({ "/apidocs", "/apidocs/", "/apidocs/**", "/flasgger_static/**", "/swaggerui/**", "/apispec_*", "/apispec*", "/swagger.json" })
+    public ResponseEntity<byte[]> proxyApiDocs(HttpServletRequest request) {
+        try {
+            var path = request.getRequestURI();
+            var query = request.getQueryString();
+            var target = modelServiceUrl;
+            if (target.endsWith("/")) {
+                target = target.substring(0, target.length() - 1);
+            }
+            var url = target + path;
+            if (query != null && !query.isEmpty()) {
+                url += "?" + query;
+            }
+
+            var rest = restTemplateBuilder.build();
+            var resp = rest.exchange(new URI(url), HttpMethod.GET, null, byte[].class);
+
+            HttpHeaders headers = new HttpHeaders();
+            var ct = resp.getHeaders().getContentType();
+            if (ct != null) {
+                headers.setContentType(ct);
+            } else {
+                headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            }
+            return new ResponseEntity<>(resp.getBody(), headers, resp.getStatusCode());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(("Error proxying /apidocs: " + e.getMessage()).getBytes());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a small proxy controller in the app service to make the model service Swagger UI accessible without exposing the model service port to the host ( because our assignment requires that only the app service is exposed on localhost ) .

So I added a simple Spring controller inside the app that forwards Swagger requests to http://model-service:8081 inside the Docker network, allowing swagger to be access at localhost:8080/apidocs.

**NOTE!** the app image has to be rebuilt to include the controller!

Please test it out and let me know if it works